### PR TITLE
1.2 do not work anymore

### DIFF
--- a/arte-downloader.user.js
+++ b/arte-downloader.user.js
@@ -3,7 +3,7 @@
 // @namespace   GuGuss
 // @description Display direct links to MP4 videos of Arte+7 programs
 // @include     http://www.arte.tv/guide/*
-// @version     1.2
+// @version     1.2.1
 // ==/UserScript==
 
 // Set this to 1 to enable console logs.


### PR DESCRIPTION
I found 2 issues in version 1.2 with Arte+7 web site :
1. The JSON URL computation did not work because of XPATH query
2. The buttons were not displayed, again because of XPATH query.

As I was not able to display the buttons next to the video, I chose to display them at the bottom of the page. Although less visible, they're less likely to disappear in future versions of the Arte+7 Web site...

Thanks for initiating this downloader, and I hope this helps...
Cyril
