### PR TITLE
Adds .editorconfig, removes x-origin req + fixes missing parent on iframe player

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+
+[*.js]
+indent_style = space
+

--- a/arte-downloader.user.js
+++ b/arte-downloader.user.js
@@ -602,6 +602,8 @@ function decoratePlayer(videoElement, videoElementIndex) {
                 // Arte Tracks
                 if (stringStartsWith(window.location.href, "http://tracks.arte")) {
                     parent = getParent(videoElement, '', "video");
+                } else {
+                    parent = document.querySelector('div.video-embed');
                 }
                 insertAfter(container, parent);
             }

--- a/arte-downloader.user.js
+++ b/arte-downloader.user.js
@@ -159,15 +159,12 @@ function preParsePlayerJson(videoElementIndex) {
 
 function parsePlayerJson(playerJsonUrl, videoElement, videoElementIndex) {
     console.log("    - #" + videoElementIndex + " player JSON: " + playerJsonUrl);
-    GM_xmlhttpRequest({
-        method: "GET",
-        url: playerJsonUrl,
-        onload: function(response) {
-            playerJson[videoElementIndex] = JSON.parse(response.responseText);
-            preParsePlayerJson(videoElementIndex);
-            decoratePlayer(videoElement, videoElementIndex);
-        }
-    });
+    let _cb = (json) => {
+        playerJson[videoElementIndex] = json;
+        preParsePlayerJson(videoElementIndex);
+        decoratePlayer(videoElement, videoElementIndex);
+    };
+    window.fetch(playerJsonUrl).then((resp) => resp.json()).then(_cb);
 }
 
 function getVideoName(videoElementIndex) {


### PR DESCRIPTION
This request adds an `.editorconfig` file.
It also removes the cross origin request warning for the iframe player and also fixes the missing parent  where the container should be inserted.

See [here](https://www.arte.tv/de/videos/067065-000-A/nacktmulle-superhelden-der-forschung/) for an example.